### PR TITLE
Fix deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: ./scripts/generate.sh all
       
     - name: Upload generated artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: generated-code
         path: gen/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           .
         
     - name: Upload release artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts-${{ steps.get_version.outputs.version }}
         path: release-artifacts/
@@ -97,7 +97,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Download release artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: release-artifacts-${{ needs.validate-and-build.outputs.version }}
         path: release-artifacts/


### PR DESCRIPTION
Updates upload-artifact and download-artifact from v3 to v4 to resolve deprecation warnings and build failures.

This fixes the issue preventing our CI/CD pipeline from running successfully.

## Changes
- Updated `actions/upload-artifact` from v3 to v4
- Updated `actions/download-artifact` from v3 to v4

## Type of Change
- [x] Build/tooling improvements
- [x] This PR is backward compatible

## Validation
- [x] Workflow syntax is valid
- [x] Actions versions are current and supported