### PR TITLE
Fix security scan configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: validate
+    permissions:
+      security-events: write
+      contents: read
     
     steps:
     - name: Checkout code
@@ -66,7 +69,7 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: ./scripts/generate.sh all
       
     - name: Upload generated artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: generated-code
         path: gen/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           .
         
     - name: Upload release artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts-${{ steps.get_version.outputs.version }}
         path: release-artifacts/
@@ -97,7 +97,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Download release artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: release-artifacts-${{ needs.validate-and-build.outputs.version }}
         path: release-artifacts/


### PR DESCRIPTION
Resolves issues with the security scanning workflow that were causing build failures.

## Changes
- Update CodeQL action from v2 to v3 (v2 is now deprecated as of Jan 2025)
- Add required `security-events: write` permission for SARIF upload
- This fixes the 'Resource not accessible by integration' error

## Type of Change
- [x] Build/tooling improvements  
- [x] This PR is backward compatible

## Validation
- [x] Workflow syntax is valid
- [x] CodeQL action version is current
- [x] Proper permissions are configured for security scanning